### PR TITLE
Changed the order in which assemblies are loaded in order. Otherwise …

### DIFF
--- a/Source/CefSharpBrowser/cefsharpbrowser.prg
+++ b/Source/CefSharpBrowser/cefsharpbrowser.prg
@@ -242,23 +242,18 @@ Procedure BindToHost (toHost, tcAddress, toConfig)
 	loBridge = This.DotNet (m.toHost)
 	
 	*--------------------------------------------------------------------------------------
-	* Load assemblies. 
+	* Load assemblies. v92 and later have an additional CefSharp.Core.Runtime.dll
 	*--------------------------------------------------------------------------------------
-	Local lcPath, llOK
+	Local lcPath, llOK, lnVersion
 	lcPath = Addbs (This.GetCefSharpPath ())
-	loBridge.LoadAssembly (m.lcPath + "CefSharp.dll")
-	loBridge.LoadAssembly (m.lcPath + "CefSharp.Core.dll")
-	loBridge.LoadAssembly (m.lcPath + "CefSharp.WinForms.dll")	
-	loBridge.LoadAssembly (m.lcPath + "fpCefSharp.dll")
-	
-	*--------------------------------------------------------------------------------------
-	* v92 and later have an additional CefSharp.Core.Runtime.dll
-	*--------------------------------------------------------------------------------------
-	Local lnVersion
 	lnVersion = This.GetMajorVersion ()
+	loBridge.LoadAssembly (m.lcPath + "CefSharp.dll")
 	If m.lnVersion >= 92
 		loBridge.LoadAssembly (m.lcPath + "CefSharp.Core.Runtime.dll")
 	EndIf
+	loBridge.LoadAssembly (m.lcPath + "CefSharp.Core.dll")
+	loBridge.LoadAssembly (m.lcPath + "CefSharp.WinForms.dll")	
+	loBridge.LoadAssembly (m.lcPath + "fpCefSharp.dll")
 	
 	*--------------------------------------------------------------------------------------
 	* Initialize Cef. Cef must be initialized exactly once per process. 

--- a/fox.cmd
+++ b/fox.cmd
@@ -18,7 +18,7 @@ rem automatically in the release process.
 
 rem DO NOT MODIFY - version {
 set versionCefSharp=v97.1.61
-set versionFpCefSharp=%versionCefSharp%.2
+set versionFpCefSharp=%versionCefSharp%.3
 rem } - DO NOT MODIFY
 
 rem These values are supposed to simplify the code


### PR DESCRIPTION
…we might load cefsharp.core.runtime.dll in a different LoadContext.

Prepared release 3.